### PR TITLE
⬆️ Qaterial v1.4.6

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -51,4 +51,4 @@ set(SFPM_REPOSITORY "https://github.com/OlivierLDff/SortFilterProxyModel.git" CA
 set(SFPM_TAG "2efec2ca6df043af03d5c01bd4b1cd318f05921f" CACHE STRING "SortFilterProxyModel git tag")
 
 set(QATERIAL_REPOSITORY "https://github.com/OlivierLDff/Qaterial.git" CACHE STRING "Qaterial repository url")
-set(QATERIAL_TAG "v1.4.5" CACHE STRING "Qaterial git tag")
+set(QATERIAL_TAG "v1.4.6" CACHE STRING "Qaterial git tag")


### PR DESCRIPTION
## Bug fix

🐛 Clipboard: fix potential nullptr access to QGuiApplication::clipboard() (happen in production somehow ...) 
3970f4b81ce43c6506b238aa27345aad72cbc961

🐛 Fix TextArea.onTextChanged not emitted properly
This fix is temporary. TextArea require entire refactor instead of ugly hack
fix https://github.com/OlivierLDff/Qaterial/issues/114
Thanks to @moodyhunter
9753c72ac41d6f1db35cb286669c4de4c5cad951

🐛 ColorTheme: Fix potential division by 0
dbd16971397e32494ea0bcf480da7c5795839d70

## Refactor

♻️ QColor *F accessors use float instead of double with Qt6
merged from : https://github.com/OlivierLDff/Qaterial/pull/111
Thanks to @moodyhunter
1210dc9e58f3a1cee9438008106a721e593a9f21

♻️ RegExpValidator to RegularExpressionValidator
merged from : https://github.com/OlivierLDff/Qaterial/pull/111
Thanks to @moodyhunter
db9501b1610f9a49e60a52bd2bcf18bc44ad4deb

♻️ Only set Qt::AA_EnableHighDpiScaling for Qt5
AA_EnableHighDpiScaling is enabled by default on qt6
merged from : https://github.com/OlivierLDff/Qaterial/pull/111
Thanks to @moodyhunter
b5a71770ccebebf8e44eb062288c4d0c20333360

## CMake

🔇 Disable Qaterial CMake log when project is included.
Log can be enabled by user using `QATERIAL_VERBOSE`
e2640eeed1c834ad0ca6078c3e7dc54633718f88

♻️ Dump cmake config after install commands
d7c4f3b8707d0a491f4697e653ba28620897e07a